### PR TITLE
update matplotlib requirements to 2.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,4 @@ Sphinx>=1.4.3
 traitlets>=4.2.2
 wcwidth>=0.1.7
 scipy>=0.17.0
-matplotlib==1.5.1
+matplotlib==2.2.4


### PR DESCRIPTION
Since matplotlib 1.5.1 does not have a wheel for python 3.6 or newer, changed it to 2.2.4